### PR TITLE
year bug fix

### DIFF
--- a/twitter_openapi_python_generated/twitter_openapi_python_generated/models/user_legacy_extended_profile_birthdate.py
+++ b/twitter_openapi_python_generated/twitter_openapi_python_generated/models/user_legacy_extended_profile_birthdate.py
@@ -30,7 +30,7 @@ class UserLegacyExtendedProfileBirthdate(BaseModel):
     day: StrictInt
     month: StrictInt
     visibility: StrictStr
-    year: StrictInt
+    year: StrictInt | None
     year_visibility: StrictStr
     __properties: ClassVar[List[str]] = ["day", "month", "visibility", "year", "year_visibility"]
 

--- a/twitter_openapi_python_generated/twitter_openapi_python_generated/models/user_verification_info_reason.py
+++ b/twitter_openapi_python_generated/twitter_openapi_python_generated/models/user_verification_info_reason.py
@@ -30,7 +30,7 @@ class UserVerificationInfoReason(BaseModel):
     UserVerificationInfoReason
     """ # noqa: E501
     description: UserVerificationInfoReasonDescription
-    override_verified_year: StrictInt
+    override_verified_year: StrictInt | None
     verified_since_msec: Annotated[str, Field(strict=True)]
     __properties: ClassVar[List[str]] = ["description", "override_verified_year", "verified_since_msec"]
 


### PR DESCRIPTION
fixes error when year or override_verified_year is None on some accounts:

"1 validation error for UserLegacyExtendedProfileBirthdate
year
  Input should be a valid integer [type=int_type, input_value=None, input_type=NoneType]"

"1 validation error for UserVerificationInfoReason
override_verified_year
  Input should be a valid integer [type=int_type, input_value=None, input_type=NoneType]"

probably a better fix but this works now

